### PR TITLE
Config file changes for GitHub pages

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -18,7 +18,7 @@ const config: Config = {
   url: 'https://your-docusaurus-site.example.com',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: '/',
+  baseUrl: '/tutorials/',
 
   // GitHub pages deployment config.
   organizationName: 'svgmap',


### PR DESCRIPTION
Tutorial / docs are now properly configured to automatically deployed via GitHub pages.